### PR TITLE
Add formatting to Slack message.

### DIFF
--- a/wordbot.py
+++ b/wordbot.py
@@ -4,6 +4,7 @@ import configparser
 import requests
 
 debug = False
+dryRun = False
 
 def lambda_handler(event, context):
 
@@ -15,32 +16,40 @@ def lambda_handler(event, context):
     wordnikUrl = config['wordnik']['apiUrl']
     wordnikKey = config['wordnik']['apiKey']
     slackUrl = config['slack']['postUrl']
-    
+
     ### 1 - connect to WordNik API
     wclient = swagger.ApiClient(wordnikKey, wordnikUrl)
     wordsApi = WordsApi.WordsApi(wclient)
-    
+
     ### 2 - get the word of the day
     wod = wordsApi.getWordOfTheDay()
     if debug:
         print (wod.word)
         for definition in wod.definitions:
+            print (definition.partOfSpeech)
             print (definition.text)
 
     ### 3 - save word for later retrieval / comparison by the listener [TBD]
+    pass
 
-    ### 4 - post message to slack
-    msg = {}
-    
-    # this needs to be fleshed out a lot to have definitions, etc
-    # check slack docs on message formatting here:
-    # https://api.slack.com/docs/messages
-    msg['text'] = wod.word
+    ### 4 - format the message for posting
+    postText = "Hey, kids! Today's Secret Word is... %s\n\n" % wod.word.upper()
+    urlWord = wod.word.replace(' ', '%20');
+    postText += "*<http://wordnik.com/words/%s|%s>*\n" % (urlWord, wod.word)
+    for idx, definition in enumerate(wod.definitions):
+        postText += "%i: _(%s)_ %s\n" % (idx+1, definition.partOfSpeech, definition.text)
+    postText += "\nRemember: if you hear the Secret Word, don't forget to SCREAM REAL LOUD!!!"""
+    print (postText)
 
-    # POST to webhook url 
-    r = requests.post(slackUrl, json.dumps(msg))
-    if debug:
-        print (r.text) 
+    ### 5 - post message to slack
+    msg = {'text': postText, 'mrkdwn': True}
+    if not dryRun:
+        r = requests.post(slackUrl, json.dumps(msg))
+        if debug:
+            print (r.text)
+    else:
+        print ('*** dry run; not posting to Slack ***')
+
 
 if __name__ == "__main__":
     # if running from the command line, set debug to true for verbose output


### PR DESCRIPTION
Multi-line formatted Slack message, with all definitions listed per word, a link to wordnik.com, and a reminder to scream real loud when the word is heard.